### PR TITLE
Fix mouse detection on startup

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -362,9 +362,9 @@ const touchpadIndicatorButton = new Lang.Class({
                 'gnome-shell-extension-prefs ' + Me.uuid)}));
         this.menu.addMenuItem(this._SettingsItem);
 
-        this._onMousePlugged();
         this._onChangeIcon();
         this._connect_signals();
+        this._onMousePlugged();
         if (switch_method_changed)
             this.gsettings.set_enum('switchmethod', this._CONF_switchMethod);
         this._showPanelIcon(this._CONF_showPanelIcon);


### PR DESCRIPTION
When starting my computer touchpad indicator would leave the touchpad in the state it was in when shutting down. This fix allows it to properly set the touchpad state on startup. 
