### PR TITLE
Add support for GNOME 3.14

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -7,7 +7,8 @@
     "3.6",
     "3.8",
     "3.10",
-    "3.12"
+    "3.12",
+    "3.14"
   ], 
   "url": "https://github.com/orangeshirt/gnome-shell-extension-touchpad-indicator", 
   "uuid": "touchpad-indicator@orangeshirt", 


### PR DESCRIPTION
As far as I using, it works for me in Fedora 21 with GNOME 3.14.
